### PR TITLE
Remove 'Data Collection' secondary heading; switch Expedia banner to static CTA; fix homepage wording; add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,13 @@
 # venv/
 # env/
 
-# Optional: If you have node_modules
-# node_modules/
+# Node / Next.js
+node_modules/
+web/node_modules/
+
+# Next.js build artifacts
+.next/
+web/.next/
+out/
+web/out/
+dist/

--- a/includes/banner.html
+++ b/includes/banner.html
@@ -1,40 +1,14 @@
-<!-- Expedia Affiliate Banner (iframe embed for reliability) -->
+<!-- Expedia Affiliate Banner (static CTA, no iframe/script) -->
 <section id="affiliate-banner" class="banner-section">
   <div style="width:100%;max-width:1200px;margin:0 auto;text-align:center;padding:15px 0;">
-    <iframe
-      class="eg-affiliate-banners-frame"
-      src="https://affiliates.expediagroup.com/products/banners?program=us-expedia&layout=leaderboard&image=mountains&message=hotel-treehouse-find-perfect-place-stay&link=stays&network=pz&camref=1011l52GG6"
-      style="width:728px;height:90px;margin:0 auto;border:none;display:block;"
-      title="Expedia Hotel Deals"
-    ></iframe>
-
-    <!-- Local fallback: shown if iframe is blocked (e.g., CSP on localhost) -->
     <a
-      id="expedia-fallback-link"
       href="https://www.expedia.com/?pwaLob=HRS&camref=1011l52GG6"
       target="_blank"
       rel="noopener"
-      style="display:none;margin:0 auto;background:#0a5cff;color:#fff;padding:12px 16px;border-radius:6px;text-decoration:none;font-weight:600"
+      style="display:inline-block;margin:0 auto;background:#0a5cff;color:#fff;padding:12px 16px;border-radius:6px;text-decoration:none;font-weight:600"
       aria-label="Find hotels on Expedia"
     >
       Find hotels on Expedia
     </a>
-
-    <script>
-      (function() {
-        var iframe = document.querySelector('#affiliate-banner iframe.eg-affiliate-banners-frame');
-        var fallback = document.getElementById('expedia-fallback-link');
-        var loaded = false;
-        if (iframe) {
-          iframe.addEventListener('load', function() { loaded = true; });
-        }
-        setTimeout(function(){
-          if (!loaded) {
-            if (fallback) fallback.style.display = 'inline-block';
-            if (iframe) iframe.style.display = 'none';
-          }
-        }, 1500);
-      })();
-    </script>
   </div>
 </section>

--- a/web/components/AffiliateBanner.tsx
+++ b/web/components/AffiliateBanner.tsx
@@ -1,17 +1,4 @@
-import { useEffect, useState } from 'react';
-
 export default function AffiliateBanner() {
-  const [loaded, setLoaded] = useState(false);
-  const [showFallback, setShowFallback] = useState(false);
-
-  useEffect(() => {
-    // If the iframe doesn't load within 1.5s (e.g., blocked by CSP on localhost), show a fallback link
-    const t = setTimeout(() => {
-      if (!loaded) setShowFallback(true);
-    }, 1500);
-    return () => clearTimeout(t);
-  }, [loaded]);
-
   return (
     <section
       id="affiliate-banner"
@@ -26,35 +13,23 @@ export default function AffiliateBanner() {
       }}
     >
       <div style={{ width: '100%', maxWidth: 1200, margin: '0 auto', textAlign: 'center' }}>
-        {!showFallback && (
-          <iframe
-            className="eg-affiliate-banners-frame"
-            src="https://affiliates.expediagroup.com/products/banners?program=us-expedia&layout=leaderboard&image=mountains&message=hotel-treehouse-find-perfect-place-stay&link=stays&network=pz&camref=1011l52GG6"
-            style={{ width: 728, height: 90, margin: '0 auto', border: 'none', display: 'block' }}
-            title="Expedia Hotel Deals"
-            onLoad={() => setLoaded(true)}
-          />
-        )}
-
-        {showFallback && (
-          <a
-            href="https://www.expedia.com/?pwaLob=HRS&camref=1011l52GG6"
-            target="_blank"
-            rel="noopener"
-            style={{
-              display: 'inline-block',
-              padding: '12px 16px',
-              background: '#0a5cff',
-              color: '#fff',
-              borderRadius: 6,
-              textDecoration: 'none',
-              fontWeight: 600,
-            }}
-            aria-label="Find hotels on Expedia"
-          >
-            Find hotels on Expedia
-          </a>
-        )}
+        <a
+          href="https://www.expedia.com/?pwaLob=HRS&camref=1011l52GG6"
+          target="_blank"
+          rel="noopener"
+          style={{
+            display: 'inline-block',
+            padding: '12px 16px',
+            background: '#0a5cff',
+            color: '#fff',
+            borderRadius: 6,
+            textDecoration: 'none',
+            fontWeight: 600,
+          }}
+          aria-label="Find hotels on Expedia"
+        >
+          Find hotels on Expedia
+        </a>
       </div>
     </section>
   );

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -80,8 +80,7 @@ export default function Home() {
             state's destiny but also contributed significantly to the industrial development of the nation.
           </p>
           <p>
-            In essence, "The Treasure State" is more than just a catchy phrase; it is a testament to Montana's extraordinary
-            <a href="/Information/geology-of-western-montana.html" className="mining-link">geological heritage</a> and the profound impact of its mineral wealth on its history, culture, and economy. It speaks to a legacy of exploration, discovery, and the enduring allure of the treasures hidden within its majestic mountains and expansive plains.
+            In essence, "The Treasure State" is more than just a catchy phrase; it is a testament to Montana's extraordinary{' '}<a href="/Information/geology-of-western-montana.html" className="mining-link">geological heritage</a> and the profound impact of its mineral wealth on its history, culture, and economy. It speaks to a legacy of exploration, discovery, and the enduring allure of the treasures hidden within its majestic mountains and expansive plains.
           </p>
         </section>
         <AffiliateBanner />


### PR DESCRIPTION
This PR removes the undesired secondary heading from Missoula content and finalizes the Expedia banner switch to a static affiliate CTA.

Changes
- cities_towns_content/Missoula, Montana Data Collection.md: remove initial H2 heading ("Missoula, Montana Data Collection") so the page starts at Quick Facts
- web/components/AffiliateBanner.tsx: use static Expedia affiliate CTA (no iframe/script) for reliability and CSP safety
- includes/banner.html: same static CTA for legacy HTML pages
- web/pages/index.tsx: fix spacing in "extraordinary geological heritage"
- .gitignore: ignore node_modules and Next.js build artifacts (.next, out) to prevent large files from being committed

This avoids iframe/X-Frame-Options/CSP issues and ensures the banner always displays. Also reduces repo bloat by ignoring build outputs.
